### PR TITLE
Fixed for working with arbitrary wordsize parameter.

### DIFF
--- a/parser/stpcommands.py
+++ b/parser/stpcommands.py
@@ -130,9 +130,6 @@ def getWeightString(variables, wordsize, ignoreMSBs=0, weightVariable="weight"):
     Asserts that the weight is equal to the hamming weight of the
     given variables.
     """
-    if len(variables) == 1:
-        return "ASSERT({} = {});\n".format(weightVariable, variables[0])
-
     command = "ASSERT(({} = BVPLUS(16,".format(weightVariable)
     for var in variables:
         tmp = "0b00000000@(BVPLUS(8, "
@@ -140,7 +137,9 @@ def getWeightString(variables, wordsize, ignoreMSBs=0, weightVariable="weight"):
             # Ignore MSBs if they do not contribute to
             # probability of the characteristic.
             tmp += "0bin0000000@({0}[{1}:{1}]),".format(var, bit)
-        command += tmp[:-1] + ")),"
+        command += tmp[:-1] + ")),"        
+    if len(variables):
+        command += "0bin0000000000000000,"
     command = command[:-1]
     command += ")));"
 


### PR DESCRIPTION
This modification makes us also able to find best differential with weight zero for one round of some ciphers, which were not detectable by the original one.